### PR TITLE
Fix cleanup in migrate script

### DIFF
--- a/bin/migrate-hack.sh
+++ b/bin/migrate-hack.sh
@@ -180,4 +180,6 @@ while true; do
 done
 
 # TRASH
-rm -f "$TEMP_FILE"
+if [ -n "$TEMP_FILE" ]; then
+  rm -f "$TEMP_FILE"
+fi


### PR DESCRIPTION
## Summary
- avoid deleting TEMP_FILE when variable isn't set

## Testing
- `shellcheck bin/migrate-hack.sh`

------
https://chatgpt.com/codex/tasks/task_e_6840259276cc8330967874ad42e677de