### PR TITLE
Fix comment typo

### DIFF
--- a/bin/migrate-hack.sh
+++ b/bin/migrate-hack.sh
@@ -86,7 +86,7 @@ copy_files() {
 
 # BLOCKS
 
-# UNCOMITTED CHANGES
+# UNCOMMITTED CHANGES
 if [[ -n $(git status --porcelain) ]]; then
   echo "⚠️ [ERROR] - There are modified, deleted, or untracked files in the repository. Please resolve these changes to continue."
   exit 1


### PR DESCRIPTION
## Summary
- fix a typo in `bin/migrate-hack.sh`

## Testing
- `grep -n UNCOMMITTED bin/migrate-hack.sh`

------
https://chatgpt.com/codex/tasks/task_e_684025847c1083308f58819d92e64ae9