### PR TITLE
Fix quoting issues in migration script

### DIFF
--- a/bin/migrate-hack.sh
+++ b/bin/migrate-hack.sh
@@ -95,7 +95,7 @@ fi
 # SERVER RUNNING
 if [ -f tmp/pids/server.pid ]; then
   PID=$(cat tmp/pids/server.pid)
-  if ps -p $PID > /dev/null; then
+if ps -p "$PID" > /dev/null; then
     echo "🔍 Server is running on PID: $PID. Checking code reload settings..."
 
     # Verifica se cache_classes está true ou false
@@ -116,6 +116,7 @@ fi
 if [ -n "$ENV_FILE" ]; then
   echo "[env] Loading environment from $ENV_FILE"
   set -a
+  # shellcheck source=/dev/null
   source "$ENV_FILE"
   set +a
 fi
@@ -143,8 +144,7 @@ while true; do
   fi
 
   echo -e "\033[1;32mPending Migrations:\033[0m"
-  echo $PENDING_MIGRATIONS
-  MIGRATION_LIST=""
+  echo "$PENDING_MIGRATIONS"
   TEMP_FILE=$(mktemp)
 
   # BUILD LIST OF MIGRATIONS AND COMMITS
@@ -160,16 +160,16 @@ while true; do
   while read -r TIMESTAMP MIGRATION COMMIT; do
     echo -e "\033[1;32mRunning migration $MIGRATION on commit $COMMIT (timestamp $TIMESTAMP)...\033[0m"
     renew_git
-    CHECKOUT=$(git -c advice.detachedHead=false checkout "$COMMIT")
+    git -c advice.detachedHead=false checkout "$COMMIT" >/dev/null
 
     copy_files
 
     bundle install > /dev/null
     echo -e "\033[1;32m - migrate\033[0m"
-    bundle exec rails db:migrate:up VERSION=$MIGRATION
+    bundle exec rails db:migrate:up VERSION="$MIGRATION"
 
     renew_git
-    git checkout $CURRENT_BRANCH > /dev/null
+    git checkout "$CURRENT_BRANCH" > /dev/null
   done < <(sort -n "$TEMP_FILE")
 
   # RESTORING YOUR REPO


### PR DESCRIPTION
## Summary
- fix quoting for PID, migration version, and branch name in script
- clean up `source` call for shellcheck
- remove unused variable assignments

## Testing
- `bash bin/migrate-hack.sh --version`
- `shellcheck bin/migrate-hack.sh`

------
https://chatgpt.com/codex/tasks/task_e_68401664d2508330bc35b4599d4b3595